### PR TITLE
Time synchronisation

### DIFF
--- a/backend/api_entrypoint.py
+++ b/backend/api_entrypoint.py
@@ -6,6 +6,7 @@ import logging
 from skychart import skychart
 from network import network_service
 import os
+from utils.system_time import get_timestamp, set_timestamp
 
 # Init logger, before we import anything else
 gunicorn_logger = logging.getLogger('gunicorn.error')
@@ -728,3 +729,14 @@ def desktop_notifications(json):
     sse.publish_event('desktop', 'notification', json)
     return { 'result': 'ok' }
 
+
+@app.route('/api/timestamp')
+@json_api
+def get_timestamp_api():
+    return get_timestamp()
+
+@app.route('/api/timestamp', methods=['POST'])
+@json_input
+@json_api
+def set_timestamp_api(json):
+    return set_timestamp(json['utc_timestamp'])

--- a/backend/api_entrypoint.py
+++ b/backend/api_entrypoint.py
@@ -740,3 +740,4 @@ def get_timestamp_api():
 @json_api
 def set_timestamp_api(json):
     return set_timestamp(json['utc_timestamp'])
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 from flask import Flask
 import json
 import os
+from utils.system_time import set_ntp
 
 
 
@@ -26,6 +27,9 @@ redis_server.start()
 REDIS_HOST = os.environ.get('REDIS_SERVER', '127.0.0.1')
 REDIS_PORT = redis_server.port
 app.config['REDIS_URL'] = 'redis://{}:{}/'.format(REDIS_HOST, REDIS_PORT)
+
+set_ntp(True)
+
 
 
 from broadcast_service import broadcast_service

--- a/backend/utils/system_time.py
+++ b/backend/utils/system_time.py
@@ -1,0 +1,25 @@
+import time
+import subprocess
+from errors import FailedMethodError
+
+def set_ntp(enabled):
+    return subprocess.run(['sudo', 'timedatectl', 'set-ntp', 'true' if enabled else 'false']).returncode == 0
+
+def get_timestamp():
+    return { 'utc_timestamp': time.time() }
+
+def set_timestamp(timestamp):
+    timestamp = int(timestamp)
+    if not __set_timestamp_timedatectl(timestamp):
+        if not __set_timestamp_date(timestamp):
+            raise FailedMethodError('Unable to set system time')
+    return get_timestamp()
+
+def __set_timestamp_timedatectl(timestamp):
+    return set_ntp(False) and subprocess.run(['sudo', 'timedatectl', 'set-time', '@{}'.format(timestamp)]).returncode == 0
+
+
+def __set_timestamp_date(timestamp):
+    return subprocess.run(['sudo', 'date', '-s', '@{}'.format(timestamp)]).returncode == 0
+
+

--- a/frontend/src/App/App.js
+++ b/frontend/src/App/App.js
@@ -21,11 +21,13 @@ import 'react-image-crop/dist/ReactCrop.css';
 import '../semantic/dist/semantic.min.css';
 import './App.css';
 import { HomeContainer } from '../Home/HomeContainer';
+import { TimeSyncModal } from './TimeSyncModal';
 
 const AppRouter = ({location}) => (
   <div className="App">
     <NavbarContainer location={location}>
         <NotificationsContainer />
+        <TimeSyncModal />
         <ErrorPageContainer>
               <Switch location={location}>
                 <Route exact path={Routes.ROOT} component={HomeContainer}/>

--- a/frontend/src/App/TimeSyncModal.js
+++ b/frontend/src/App/TimeSyncModal.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { dismissTimeSyncModal, backendTimeSync } from './actions';
+import { timeSyncModalSelector } from './selectors';
+import { Button, Modal } from 'semantic-ui-react';
+
+const TimeSyncModalComponent = ({ showTimeSyncModal, dismissTimeSyncModal, backendTimeSync }) => showTimeSyncModal && (
+    <Modal open basic>
+        <Modal.Header>Time Synchronisation</Modal.Header>
+        <Modal.Content>
+            <p>Your backend server time seems to be out of sync.</p>
+            <p>Do you want to synchronise it?</p>
+        </Modal.Content>
+        <Modal.Actions>
+            <Button onClick={dismissTimeSyncModal}>Cancel</Button>
+            <Button onClick={backendTimeSync} primary>Synchronise</Button>
+        </Modal.Actions>
+    </Modal>
+)
+
+export const TimeSyncModal = connect(timeSyncModalSelector, { dismissTimeSyncModal, backendTimeSync })(TimeSyncModalComponent);
+

--- a/frontend/src/App/actions.js
+++ b/frontend/src/App/actions.js
@@ -1,4 +1,4 @@
-import { fetchBackendVersion } from '../middleware/api';
+import { fetchBackendVersion, fetchBackendTimestampAPI, setBackendTimestampAPI } from '../middleware/api';
 import listenToEvents from '../middleware/events';
 import { isError } from '../Errors/selectors.js';
 import Actions from '../actions';
@@ -32,6 +32,17 @@ export const getBackendVersion = () => (dispatch, getState) => {
     });
 }
 
+export const dismissTimeSyncModal = () => ({ type: 'TIME_SYNC_MODAL_DISMISS' });
+
+const receivedBackendTimestamp = payload => ({ type: 'BACKEND_TIMESTAMP_FETCHED', payload });
+
+export const backendTimeSync = () => dispatch => {
+    dispatch(dismissTimeSyncModal());
+    setBackendTimestampAPI(dispatch, { utc_timestamp: new Date().getTime() / 1000.0 }, receivedBackendTimestamp, () => dispatch(addNotification('Time Synchronisation failed', 'Failed to set time on backend server', 'warning', 5000)) );
+};
+
+export const getBackendTimestamp = () => dispatch => fetchBackendTimestampAPI(dispatch, payload => dispatch(receivedBackendTimestamp(payload)));
+
 export const init = () => async (dispatch, getState) => {
     if(retryTimer) {
         clearTimeout(retryTimer);
@@ -58,5 +69,6 @@ export const init = () => async (dispatch, getState) => {
     dispatch(getCatalogs());
     dispatch(getPHD2Status());
     dispatch(getNetworkManagerStatus());
+    dispatch(getBackendTimestamp());
     listenToEvents(dispatch);
 }

--- a/frontend/src/App/reducer.js
+++ b/frontend/src/App/reducer.js
@@ -3,12 +3,18 @@ import PackageInfo from '../../package.json';
 const defaultState = {
     frontend: { version: PackageInfo.version },
     backend: {},
+    timeSyncNeeded: false,
+    timeSyncModalDismissed: false,
 };
 
 export const app = (state = defaultState, action) => {
     switch (action.type) {
         case 'BACKEND_VERSION_FETCHED':
             return { ...state, backend: action.version };
+        case 'TIME_SYNC_MODAL_DISMISS':
+            return {...state, timeSyncModalDismissed: true };
+        case 'BACKEND_TIMESTAMP_FETCHED':
+            return { ...state, timeSyncNeeded: Math.abs( (new Date().getTime() / 1000.0) - action.payload.utc_timestamp ) > 30 };
         default:
             return state;
     }

--- a/frontend/src/App/selectors.js
+++ b/frontend/src/App/selectors.js
@@ -1,6 +1,14 @@
 import { get } from 'lodash';
+import { createSelector } from 'reselect';
 
 export const getFrontendVersion = state => get(state, 'app.frontend.version');
 export const getBackendVersion = state => get(state, 'app.backend.version');
+
+const getTimeSyncModalDismissed = state => state.app.timeSyncModalDismissed;
+const getTimeSyncNeeded = state => state.app.timeSyncNeeded;
+
+export const timeSyncModalSelector = createSelector([getTimeSyncModalDismissed, getTimeSyncNeeded], (timeSyncModalDismissed, timeSyncNeeded) => ({ 
+    showTimeSyncModal: timeSyncNeeded && ! timeSyncModalDismissed,
+}));
 
 

--- a/frontend/src/Modals/ModalDialog.js
+++ b/frontend/src/Modals/ModalDialog.js
@@ -45,7 +45,7 @@ export class ModalDialog extends React.Component {
         const {open, trigger, onModalOpened, onModalClosed, triggerAction = 'onClick', children, closeOnEscape, ...rest} = this.props;
         return (
             <React.Fragment>
-                { React.cloneElement(trigger, { [triggerAction]: this.open }) }
+                { trigger && React.cloneElement(trigger, { [triggerAction]: this.open }) }
                     <Modal onClose={this.onClose} open={this.state.open} {...rest}>
                         <ModalDialogContext.Provider value={{close: this.close}}>
                             {children}

--- a/frontend/src/middleware/api.js
+++ b/frontend/src/middleware/api.js
@@ -59,6 +59,12 @@ const fetchJSON = async (dispatch, url, options, onSuccess, onError) => {
 }
 
 export const fetchBackendVersion = (dispatch, onSuccess) => fetchJSON(dispatch, '/api/version', {}, json => onSuccess(json));
+export const fetchBackendTimestampAPI = (dispatch, onSuccess) => fetchJSON(dispatch, '/api/timestamp', {}, json => onSuccess(json));
+export const setBackendTimestampAPI = (dispatch, payload, onSuccess, onError) => fetchJSON(dispatch, '/api/timestamp', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: headersJSONRequest,
+}, onSuccess, onError);
 
 export const startSequenceAPI = (dispatch, sequence, onSuccess, onError) => fetchJSON(dispatch, `/api/sequences/${sequence.id}/start`, {
         method: 'POST',


### PR DESCRIPTION
On Rasberry Pi and other devices without a hardware RTC clock, backend time might get out of sync when not connected to internet.

This feature relies on the time difference between server and client; assuming your client device is in sync (mobile phone or laptop with hardware RTC) it can then synchronise the server time to it.