### PR TITLE
Fix Groups overflow on Device page

### DIFF
--- a/frontend/src/INDI-Server/INDIDevicePage.js
+++ b/frontend/src/INDI-Server/INDIDevicePage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu, Container } from 'semantic-ui-react';
+import { Menu, Grid} from 'semantic-ui-react';
 import { INDIDeviceGroupContainer } from './INDIDeviceGroupContainer';
 import { INDIMessagesPanel } from './INDIMessagesPanel';
 import { Route, Redirect } from 'react-router';
@@ -25,15 +25,19 @@ export class INDIDevicePage extends React.PureComponent {
         if(! device)
             return <NotFoundPage backToUrl='/indi/server' message='INDI Device not found. Perhaps you need to connect to your INDI server?' backButtonText='INDI server page' />
         return (
-            <Container>
-                <Menu secondary stackable>
-                    <Menu.Item header content='Groups' />
-                    { device.groups.map(this.renderGroup)}
-                </Menu>
-                <Route path="/indi/:deviceId/:groupName" render={this.renderGroupContainer} />
-                <Route path="/indi/:deviceId" exact={true} render={this.renderRedirect} />
+            <Grid stackable>
+                <Grid.Column width={2}>
+                    <Menu secondary vertical fluid>
+                        <Menu.Item header content='Groups' />
+                        { device.groups.map(this.renderGroup)}
+                    </Menu>
+                </Grid.Column>
+                <Grid.Column width={14}>
+                    <Route path="/indi/:deviceId/:groupName" render={this.renderGroupContainer} />
+                    <Route path="/indi/:deviceId" exact={true} render={this.renderRedirect} />
+                </Grid.Column>
                 <INDIMessagesPanel messages={get(messages, device.id, [])} />
-            </Container>
+            </Grid>
         );
     }
 }

--- a/frontend/src/INDI-Server/INDIServerPage.js
+++ b/frontend/src/INDI-Server/INDIServerPage.js
@@ -55,8 +55,8 @@ class INDIServerPage extends React.PureComponent {
 
 
     render = () => (
-        <Container>
-            <Menu stackable>
+        <Container fluid>
+            <Menu stackable fluid>
                 <Menu.Item as={NavLink} exact={true} to="/indi/server">INDI Server</Menu.Item>
                 { this.props.devices.map(this.renderDeviceMenuItem)}
             </Menu>


### PR DESCRIPTION
Using a vertical menu instead of a horizontal one for device groups.
This scales better when devices have lots of groups.
Also making INDI page wider to better handle case when lots of devices are attached.