### PR TITLE
Fix GPhoto INDI initialisation error

### DIFF
--- a/backend/indi/indi_property.py
+++ b/backend/indi/indi_property.py
@@ -49,7 +49,7 @@ class Property:
         elif name and device:
             self.__init_by_values(device, group, name, label, property_type)
         else:
-            raise RuntimeError('Property initialization error')
+            raise RuntimeError('Property initialization error: {}/{}/{}, label={}, type: {}'.format(device, group, name, label, property_type))
         self.id = '{}/{}'.format(self.device, self.name)
 
     @with_indi_property

--- a/backend/indi/server.py
+++ b/backend/indi/server.py
@@ -124,7 +124,10 @@ class Server:
         self.event_listener.on_indi_property_updated(self.property(indi_vector_property=vector_property))
 
     def __on_property_added(self, device, group, property_name):
-        self.event_listener.on_indi_property_added(self.property(device=device, group=group, name=property_name))
+        try:
+            self.event_listener.on_indi_property_added(self.property(device=device, group=group, name=property_name))
+        except RuntimeError as e:
+            self.logger.warning('Error on property added: {}'.format(e))
         
     def __on_property_removed(self, indi_property):
         self.event_listener.on_indi_property_removed(self.property(indi_device_property=indi_property))


### PR DESCRIPTION
On some INDI devices (Canon cameras with the GPhoto driver) there seems to be a property with no name/label, which created a crash in the backend server.

This adds a workaround for it.